### PR TITLE
fix for removal of node_events.h

### DIFF
--- a/pcap_binding.cc
+++ b/pcap_binding.cc
@@ -1,5 +1,4 @@
 #include <node.h>
-#include <node_events.h>
 #include <node_buffer.h>
 #include <node_version.h>
 #include <assert.h>


### PR DESCRIPTION
seems node_events.h was removed in node commit 707b1dee84685c0c17530d568192455cdf790078

this patch removes the dep on that header,  and things still compile just fine
