### PR TITLE
Update to SocketWatcher 0.2.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
         "url": "git://github.com/mranney/node_pcap.git"
     },
     "dependencies": {
-      "socketwatcher": "~0.1.0"
+      "socketwatcher": "~0.2.0"
     }
 }

--- a/pcap.js
+++ b/pcap.js
@@ -6,7 +6,7 @@ var util          = require('util'),
     binding       = require('./build/Release/pcap_binding'),
     HTTPParser    = process.binding('http_parser').HTTPParser,
     url           = require('url'),
-    SocketWatcher = require("socketwatcher");
+    SocketWatcher = require("socketwatcher").SocketWatcher;
 
 function Pcap() {
     this.opened = false;


### PR DESCRIPTION
There was a bug in SocketWatcher 0.1.x that prevented it from compiling on Node 0.8.x. C.f. https://github.com/btrask/node-socketwatcher/issues/2

Sorry for the trouble.
