### PR TITLE
Upgrade socketwatcher dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
         "url": "git://github.com/mranney/node_pcap.git"
     },
     "dependencies": {
-      "socketwatcher": "~0.1.0"
+      "socketwatcher": "~0.2.0"
     }
 }

--- a/pcap.js
+++ b/pcap.js
@@ -6,7 +6,7 @@ var util          = require('util'),
     binding       = require('./build/Release/pcap_binding'),
     HTTPParser    = process.binding('http_parser').HTTPParser,
     url           = require('url'),
-    SocketWatcher = require("socketwatcher");
+    SocketWatcher = require("socketwatcher").SocketWatcher;
 
 function Pcap() {
     this.opened = false;


### PR DESCRIPTION
0.2.0 fixes backwards compatibility with node < 0.9.9.
See github issue btrask/node-socketwatcher#2 for details.
