### PR TITLE
added cstring to pcap_session.cc to get rid of compiler error 

### DIFF
--- a/pcap_session.cc
+++ b/pcap_session.cc
@@ -3,6 +3,7 @@
 #include <assert.h>
 #include <pcap/pcap.h>
 #include <sys/ioctl.h>
+#include <cstring>
 
 #include "pcap_session.h"
 


### PR DESCRIPTION
memcpy not C++ namespace. Caused Error during npm installation
