### PR TITLE
Removed pcap.h which was leading to a compilation failure on Windows 7

### DIFF
--- a/pcap_binding.cc
+++ b/pcap_binding.cc
@@ -2,7 +2,6 @@
 #include <node_buffer.h>
 #include <node_version.h>
 #include <assert.h>
-#include <pcap/pcap.h>
 #include <v8.h>
 #include <iostream>
 #include <stdio.h>


### PR DESCRIPTION
Fixes #76
