### PR TITLE
Fix crash opening offline file.

### DIFF
--- a/pcap_binding.cc
+++ b/pcap_binding.cc
@@ -101,8 +101,12 @@ DefaultDevice(const Arguments& args)
     pcap_addr_t *addr;
     bool found = false;
 
-    if (pcap_findalldevs(&alldevs, errbuf) == -1 || alldevs == NULL) {
+    if (pcap_findalldevs(&alldevs, errbuf) == -1) {
         return ThrowException(Exception::Error(String::New(errbuf)));
+    }
+
+    if (alldevs == NULL) {
+        return ThrowException(Exception::Error(String::New("pcap_findalldevs didn't find any devs")));
     }
 
     for (dev = alldevs; dev != NULL; dev = dev->next) {

--- a/pcap_session.cc
+++ b/pcap_session.cc
@@ -218,16 +218,15 @@ PcapSession::Open(bool live, const Arguments& args)
             }
         }
 
+        if (pcap_setnonblock(session->pcap_handle, 1, errbuf) == -1) {
+          return ThrowException(Exception::Error(String::New(errbuf)));
+        }
     } else {
         // Device is the path to the savefile
         session->pcap_handle = pcap_open_offline((char *) *device, errbuf);
         if (session->pcap_handle == NULL) {
             return ThrowException(Exception::Error(String::New(errbuf)));
         }
-    }
-
-    if (pcap_setnonblock(session->pcap_handle, 1, errbuf) == -1) {
-        return ThrowException(Exception::Error(String::New(errbuf)));
     }
 
     if (filter.length() != 0) {


### PR DESCRIPTION
Newer versions of libpcap don't let you set nonblocking mode on
files (and apparently don't set a useful error message).

Should resolve #57 and #71
