### PR TITLE
Make sure pcap_handle is allocated before attempting close.

### DIFF
--- a/pcap_session.cc
+++ b/pcap_session.cc
@@ -313,7 +313,9 @@ void PcapSession::Close(const Nan::FunctionCallbackInfo<Value>& info)
         session->pcap_dump_handle = NULL;
     }
 
-    pcap_close(session->pcap_handle);
+    if (session->pcap_handle != NULL) {
+        pcap_close(session->pcap_handle);
+    }
     session->packet_ready_cb.Reset();
     return;
 }


### PR DESCRIPTION
If the PcapSession close method is inadvertently called more than once, it results in a malloc "pointer being freed was not allocated" error.  I believe it should cleanly return even if it is essentially a no-op call.
