### PR TITLE
Add snaplength parameter to createSession

### DIFF
--- a/pcap.js
+++ b/pcap.js
@@ -12,11 +12,12 @@ exports.TCPTracker = tcp_tracker.TCPTracker;
 exports.TCPSession = tcp_tracker.TCPSession;
 exports.DNSCache = DNSCache;
 
-function PcapSession(is_live, device_name, filter, buffer_size, outfile, is_monitor) {
+function PcapSession(is_live, device_name, filter, buffer_size, snap_length, outfile, is_monitor) {
     this.is_live = is_live;
     this.device_name = device_name;
     this.filter = filter || "";
     this.buffer_size = buffer_size;
+    this.snap_length = snap_length;
     this.outfile = outfile || "";
     this.is_monitor = Boolean(is_monitor);
 
@@ -37,6 +38,12 @@ function PcapSession(is_live, device_name, filter, buffer_size, outfile, is_moni
         this.buffer_size = 10 * 1024 * 1024; // Default buffer size is 10MB
     }
 
+    if (typeof this.snap_length === "number" && !isNaN(this.snap_length)) {
+        this.snap_length = Math.round(this.snap_length);
+    } else {
+        this.snap_length = 65535; // Default snap length is 65535
+    }
+
     var self = this;
 
     // called for each packet read by pcap
@@ -46,14 +53,14 @@ function PcapSession(is_live, device_name, filter, buffer_size, outfile, is_moni
 
     if (this.is_live) {
         this.device_name = this.device_name || binding.default_device();
-        this.link_type = this.session.open_live(this.device_name, this.filter, this.buffer_size, this.outfile, packet_ready, this.is_monitor);
+        this.link_type = this.session.open_live(this.device_name, this.filter, this.buffer_size, this.snap_length, this.outfile, packet_ready, this.is_monitor);
     } else {
-        this.link_type = this.session.open_offline(this.device_name, this.filter, this.buffer_size, this.outfile, packet_ready, this.is_monitor);
+        this.link_type = this.session.open_offline(this.device_name, this.filter, this.buffer_size, this.snap_length, this.outfile, packet_ready, this.is_monitor);
     }
 
     this.fd = this.session.fileno();
     this.opened = true;
-    this.buf = new Buffer(this.buffer_size || 65535);
+    this.buf = new Buffer(this.snap_length);
     this.header = new Buffer(16);
 
     if (is_live) {
@@ -119,8 +126,8 @@ PcapSession.prototype.inject = function (data) {
 exports.Pcap = PcapSession;
 exports.PcapSession = PcapSession;
 
-exports.createSession = function (device, filter, buffer_size, monitor) {
-    return new PcapSession(true, device, filter, buffer_size, null, monitor);
+exports.createSession = function (device, filter, buffer_size, snap_length, monitor) {
+    return new PcapSession(true, device, filter, buffer_size, snap_length, null, monitor);
 };
 
 exports.createOfflineSession = function (path, filter) {

--- a/pcap_session.cc
+++ b/pcap_session.cc
@@ -70,10 +70,8 @@ void PcapSession::PacketReady(u_char *s, const struct pcap_pkthdr* pkthdr, const
 
     size_t copy_len = pkthdr->caplen;
 
-    // if the length of the packet is actually bigger than the snaplength
-    // just use the snaplength, truncating the original.
-    if (copy_len > session->snap_length) {
-        copy_len = session->snap_length;
+    if (copy_len > session->buffer_length) {
+        copy_len = session->buffer_length;
     }
 
     memcpy(session->buffer_data, packet, copy_len);

--- a/pcap_session.cc
+++ b/pcap_session.cc
@@ -169,7 +169,7 @@ void PcapSession::Open(bool live, const Nan::FunctionCallbackInfo<Value>& info)
     Nan::Utf8String device(info[0]->ToString());
     Nan::Utf8String filter(info[1]->ToString());
     int buffer_size = info[2]->Int32Value();
-    int snap_length = info[3]->Int32Value() || 65535;
+    int snap_length = info[3]->Int32Value();
     Nan::Utf8String pcap_output_filename(info[4]->ToString());
 
     PcapSession* session = Nan::ObjectWrap::Unwrap<PcapSession>(info.This());

--- a/pcap_session.cc
+++ b/pcap_session.cc
@@ -69,11 +69,15 @@ void PcapSession::PacketReady(u_char *s, const struct pcap_pkthdr* pkthdr, const
     }
 
     size_t copy_len = pkthdr->caplen;
-    if (copy_len > session->buffer_length) {
-        copy_len = session->buffer_length;
-    }
-    memcpy(session->buffer_data, packet, copy_len);
 
+    // if the length of the packet is actually bigger than the snaplength
+    // just use the snaplength, truncating the original.
+    if (copy_len > session->snap_length) {
+        copy_len = session->snap_length;
+    }
+
+    memcpy(session->buffer_data, packet, copy_len);
+    
     // copy header data to fixed offsets in second buffer from user
     memcpy(session->header_data, &(pkthdr->ts.tv_sec), 4);
     memcpy(session->header_data + 4, &(pkthdr->ts.tv_usec), 4);
@@ -129,7 +133,7 @@ void PcapSession::Open(bool live, const Nan::FunctionCallbackInfo<Value>& info)
     Nan::HandleScope scope;
     char errbuf[PCAP_ERRBUF_SIZE];
 
-    if (info.Length() == 6) {
+    if (info.Length() == 7) {
         if (!info[0]->IsString()) {
             Nan::ThrowTypeError("pcap Open: info[0] must be a String");
             return;
@@ -142,30 +146,35 @@ void PcapSession::Open(bool live, const Nan::FunctionCallbackInfo<Value>& info)
             Nan::ThrowTypeError("pcap Open: info[2] must be a Number");
             return;
         }
-        if (!info[3]->IsString()) {
-            Nan::ThrowTypeError("pcap Open: info[3] must be a String");
+        if (!info[3]->IsInt32()) {
+            Nan::ThrowTypeError("pcap Open: info[3] must be a Number");
             return;
         }
-        if (!info[4]->IsFunction()) {
-            Nan::ThrowTypeError("pcap Open: info[4] must be a Function");
+        if (!info[4]->IsString()) {
+            Nan::ThrowTypeError("pcap Open: info[4] must be a String");
             return;
         }
-        if (!info[5]->IsBoolean()) {
-            Nan::ThrowTypeError("pcap Open: info[5] must be a Boolean");
+        if (!info[5]->IsFunction()) {
+            Nan::ThrowTypeError("pcap Open: info[5] must be a Function");
+            return;
+        }
+        if (!info[6]->IsBoolean()) {
+            Nan::ThrowTypeError("pcap Open: info[6] must be a Boolean");
             return;
         }
     } else {
-        Nan::ThrowTypeError("pcap Open: expecting 6 arguments");
+        Nan::ThrowTypeError("pcap Open: expecting 7 arguments");
         return;
     }
     Nan::Utf8String device(info[0]->ToString());
     Nan::Utf8String filter(info[1]->ToString());
     int buffer_size = info[2]->Int32Value();
-    Nan::Utf8String pcap_output_filename(info[3]->ToString());
+    int snap_length = info[3]->Int32Value() || 65535;
+    Nan::Utf8String pcap_output_filename(info[4]->ToString());
 
     PcapSession* session = Nan::ObjectWrap::Unwrap<PcapSession>(info.This());
 
-    session->packet_ready_cb.Reset(info[4].As<Function>());
+    session->packet_ready_cb.Reset(info[5].As<Function>());
     session->pcap_dump_handle = NULL;
 
     if (live) {
@@ -182,7 +191,7 @@ void PcapSession::Open(bool live, const Nan::FunctionCallbackInfo<Value>& info)
         }
 
         // 64KB is the max IPv4 packet size
-        if (pcap_set_snaplen(session->pcap_handle, 65535) != 0) {
+        if (pcap_set_snaplen(session->pcap_handle, snap_length) != 0) {
             Nan::ThrowError("error setting snaplen");
             return;
         }
@@ -206,8 +215,8 @@ void PcapSession::Open(bool live, const Nan::FunctionCallbackInfo<Value>& info)
         }
 
         // fixes a previous to-do that was here.
-        if (info.Length() == 6) {
-            if (info[5]->Int32Value()) {
+        if (info.Length() == 7) {
+            if (info[6]->Int32Value()) {
                 if (pcap_set_rfmon(session->pcap_handle, 1) != 0) {
                     Nan::ThrowError(pcap_geterr(session->pcap_handle));
                     return;

--- a/pcap_session.h
+++ b/pcap_session.h
@@ -33,6 +33,7 @@ private:
     pcap_dumper_t *pcap_dump_handle;
     char *buffer_data;
     size_t buffer_length;
+    size_t snap_length;
     char *header_data;
 };
 


### PR DESCRIPTION
Adds the snap length as an parameter to the createSession method alongside the buffer size and passes it onto libpcap appropriately, packet ready events are also now appropriately sized to the requested snap length instead of buffer size.