### PR TITLE
Fixed the deprecated message for Node v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "nan": "^2.0.9",
-    "socketwatcher": "^0.3.0"
+    "socketwatcher": "git+https://github.com/bytzdev/node-socketwatcher.git"
   },
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/pcap_session.cc
+++ b/pcap_session.cc
@@ -43,7 +43,7 @@ void PcapSession::New(const Nan::FunctionCallbackInfo<Value>& info) {
   } else {
     // Invoked as plain function `MyObject(...)`, turn into construct call.
     Local<Function> cons = Nan::New<Function>(constructor);
-    info.GetReturnValue().Set(cons->NewInstance());
+    info.GetReturnValue().Set(Nan::NewInstance(cons).ToLocalChecked());
   }
 }
 


### PR DESCRIPTION
Issue from #242  
Change the socketwatcher to [this](https://github.com/bytzdev/node-socketwatcher/commit/d252d3f8c45f565a0a48ebd155d4f9e4666798d9) solution .
And also edit pcap_session.cc like socketwatcher for v10