### PR TITLE
[WIP] error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##Disclaimer
+## Disclaimer
 node_pcap is currently being heavily refactored much of the documentation is out of date. If you installed node_pcap from npm go to [v2.0.1](https://github.com/mranney/node_pcap/commit/6e4d56671c54e0cf690f72b92554a538244bd1b6). Thanks for your patience and contributions as we work on the next major version of node_pcap.
 
 node_pcap

--- a/decode/ethernet_packet.js
+++ b/decode/ethernet_packet.js
@@ -49,7 +49,7 @@ EthernetPacket.prototype.decode = function (raw_packet, offset) {
             this.payload = "need to implement LLDP";
             break;
         default:
-            console.log("node_pcap: EthernetFrame() - Don't know how to decode ethertype " + this.ethertype);
+            this.emitter.emit("warning", "node_pcap: EthernetFrame() - Don't know how to decode ethertype " + this.ethertype);
         }
     }
 

--- a/decode/pcap_packet.js
+++ b/decode/pcap_packet.js
@@ -49,7 +49,7 @@ PcapPacket.prototype.decode = function (packet_with_header) {
         this.payload = new SLLPacket(this.emitter).decode(buf, 0);
         break;
     default:
-        console.log("node_pcap: PcapPacket.decode - Don't yet know how to decode link type " + this.link_type);
+        this.emitter.emit("warning", "node_pcap: PcapPacket.decode - Don't yet know how to decode link type " + this.link_type);
     }
 
     return this;

--- a/decode/sll_packet.js
+++ b/decode/sll_packet.js
@@ -47,7 +47,7 @@ SLLPacket.prototype.decode = function (raw_packet, offset) {
             this.payload = "need to implement LLDP";
             break;
         default:
-            console.log("node_pcap: SLLPacket() - Don't know how to decode ethertype " + this.ethertype);
+            this.emitter.emit("warning", "node_pcap: SLLPacket() - Don't know how to decode ethertype " + this.ethertype);
         }
     }
 

--- a/decode/tcp.js
+++ b/decode/tcp.js
@@ -148,6 +148,7 @@ TCPOptions.prototype.decode = function (raw_packet, offset, len) {
             break;
         default:
             this.emitter.emit("warning", "Don't know how to process TCP option " + raw_packet[offset]);
+            offset = end_offset;
         }
     }
 

--- a/decode/tcp.js
+++ b/decode/tcp.js
@@ -128,7 +128,7 @@ TCPOptions.prototype.decode = function (raw_packet, offset, len) {
                 offset += 8;
                 break;
             default:
-                console.log("Invalid TCP SACK option length " + raw_packet[offset + 1]);
+                this.emitter.emit("warning", "Invalid TCP SACK option length " + raw_packet[offset + 1]);
                 offset = end_offset;
             }
             break;
@@ -147,7 +147,7 @@ TCPOptions.prototype.decode = function (raw_packet, offset, len) {
             offset += raw_packet.readUInt8(offset + 1);
             break;
         default:
-            throw new Error("Don't know how to process TCP option " + raw_packet[offset]);
+            this.emitter.emit("warning", "Don't know how to process TCP option " + raw_packet[offset]);
         }
     }
 


### PR DESCRIPTION
Hey, I replaced all the logged warnings with emitting an event. Also, unknown TCP options no longer result in a thrown error but also in an emitted warning. That should fix #240 and fix #183. I might add some tests, so **please don't merge it yet**.

This is a breaking change, so it should be published with the next major version. Before doing so it might be a good idea to agree on a general concept of handling errors. If decoding a higher level protocol fails, should the complete decoding fail or just leave part of it encoded and emit a warning? For example, the DNS decoder does throw some errors. Should lower level protocols handle these?